### PR TITLE
Cannot access self:: when no class scope is active

### DIFF
--- a/src/LZCompressor/LZUtil.php
+++ b/src/LZCompressor/LZUtil.php
@@ -40,7 +40,7 @@ class LZUtil
     public static function fromCharCode()
     {
         return array_reduce(func_get_args(), function ($a, $b) {
-            $a .= self::utf8_chr($b);
+            $a .= LZUtil::utf8_chr($b);
             return $a;
         });
     }


### PR DESCRIPTION
ix the error in PHP 5.3
Fatal error: Cannot access self:: when no class scope is active in ...\LZCompressor\LZUtil.php on line 43