### PR TITLE
fix: lz-string-php compression overhead removed

### DIFF
--- a/src/LZCompressor/LZData.php
+++ b/src/LZCompressor/LZData.php
@@ -19,10 +19,18 @@ class LZData
     public $position = 0;
 
     /**
-     * @var int
+     * @var int - index of letters (may be multiple of characters)
      */
     public $index = 1;
-
+    
+    /*
+     * @var bool - set to true if theindex is out of str range
+     */
+    public $end = true;
+    
+    /**
+     * @param unknown $str
+     */
     public function append($str) {
         $this->str .= $str;
     }

--- a/src/LZCompressor/LZUtil16.php
+++ b/src/LZCompressor/LZUtil16.php
@@ -40,9 +40,13 @@ class LZUtil16
      *
      * @return bool|integer
      */
-    public static function charCodeAt($str, $num=0)
+    public static function charCodeAt($data)
     {
-        return self::utf16_ord(self::utf16_charAt($str, $num));
+        $sub = substr($data->str, $data->index, 2);
+        $sub = self::utf16_charAt($sub, 0);
+        $data->index += strlen($sub);
+        $data->end = strlen($sub) <= 0;
+        return self::utf16_ord($sub);
     }
 
     /**


### PR DESCRIPTION
This pull request does fix overhead that happens with PHP UTF-8 string indexing. The calculation complexity was raising exponentially and became unusable when the compressed message was even less than 1MBytes.